### PR TITLE
Optionally use component file name as scope, instead of hash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,26 @@ gulp.task("vuesplit", function() {
 
 This generates the extract/processed `.html`, `.css`, `.js` files to the same folder as the source `.vue` file.
 
+## Configuration
 
+Currently vuesplit can be configured with the following settings:
+
+  * `cssFilenameScoped` : instead of postfixing created CSS classes with a unique hash, *prefix* the name of the generated CSS with the name of the component file.
+
+
+Example:
+
+```js
+import vueSplit from "gulp-vuesplit"
+
+gulp.task("vuesplit", function() {
+  return gulp.src("src/**/*.vue").
+    pipe(vueSplit({cssFilenameScoped: true})).
+    pipe(gulp.dest("."))
+})
+
+
+```
 ## Example Vue-File (Test.vue)
 
 ```vue

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,12 @@ export function generateScopedName(name, filename)
   return `${name}-${generateHash(filename)}`
 }
 
-export default function vueSplitPlugin()
+export function generateScopedNameFilename(name, filename)
+{
+  return `${pathModule.basename(filename).split('.')[0]}-${name}`
+}
+
+export default function vueSplitPlugin(config={})
 {
   var moduleMapping = null
 
@@ -117,9 +122,15 @@ export default function vueSplitPlugin()
     if (!text)
       return done()
 
+    let scopeNameFn = generateScopedName
+
+    if ( config.cssFilenameScoped ) {
+      scopeNameFn = generateScopedNameFilename
+    }
+
     return postcss([
       postcssModules({
-        generateScopedName: generateScopedName,
+        generateScopedName: scopeNameFn,
         getJSON: function(cssFileName, json)
         {
           moduleMapping = json


### PR DESCRIPTION
Howdy,

I really like the idea of being able to pull out the parts of a `.vue` file into separate files!

Thinking about it, I wanted a way to use single file components in older, pre-component architectures. Auto namespacing the CSS would really work here, plus the reduced cognitive load of having the CSS and JS (and template) in the same file.

I really liked the idea of auto-namespacing, but the hash means I can't easily use the CSS and JS by itself. Thus, this PR: it allows the user to change up the CSS auto namespacing scheme: from postfixed with a hash to prefixed with the name of the file.

Thanks for the awesome project. Let me know if there's anything that needs changing in the PR!